### PR TITLE
updated main.py - added a short sleep after nmap

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ ip="192.168.1.3" #Enter the IP address of the device that should keep the displa
 
 while True:
     nmap_out=str(popen('nmap -sP '+ip).read()) #nmap command to scan on the given IP address
-
+    sleep(2)
+    
     if nmap_out.find('latency') == -1:  #looks for the word "latency" in the output
         if state==0 :                   #this nested if makes sure that commands are not repeated
             pass


### PR DESCRIPTION
after the nmap scan sometimes it would turn the display off and then immediately back on, I guess it was checking for "latency" before the whole nmap output had even appeared. So I added a short sleep after the scan, before the find statements which fixed this up for me.

EDIT: I also changed the primary sleep (at the bottom) to 20 seconds in my implementation, but thats obviously up to you - I think 5 sec is a bit too often/fast.